### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   mypy:
     name: MyPy
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/modal-examples/security/code-scanning/19](https://github.com/hixio-mh/modal-examples/security/code-scanning/19)

The best way to fix this problem is to explicitly restrict the permissions granted to the GITHUB_TOKEN for this workflow or the affected job. In this specific workflow, only read access is required to `contents` for the actions/checkout step; none of the steps require modifying repository contents, issues, or pull requests. There are two ways to set permissions: globally at the root of the workflow file, or directly under the affected job. Here, adding `permissions: contents: read` to the `mypy` job is the minimal and recommended fix, limiting permissions just for that job, as flagged by the static analysis.

To implement the fix, insert the following under the job definition (after `name: MyPy` and before `runs-on: ...`):

```yaml
permissions:
  contents: read
```

No further imports, dependencies, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
