### PR TITLE
Potential fix for code scanning alert no. 9: Binding a socket to all network interfaces

### DIFF
--- a/misc/quic/quic_yolo_modal.py
+++ b/misc/quic/quic_yolo_modal.py
@@ -403,6 +403,7 @@ async def yolo_quic_server(
     rendezvous_url: str,
     target_id: str,
     local_port: int = 5555,
+    local_ip: str = "127.0.0.1",
 ):
     import aiohttp
     import cv2
@@ -413,7 +414,7 @@ async def yolo_quic_server(
 
     # discover public mapping via STUN
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.bind(("0.0.0.0", local_port))
+    sock.bind((local_ip, local_port))
     sock.setblocking(False)
 
     pub_ip, pub_port = await get_ext_addr(sock)


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/modal-examples/security/code-scanning/9](https://github.com/hixio-mh/modal-examples/security/code-scanning/9)

To fix the problem, the socket should be bound to a specific interface rather than all interfaces. For UDP hole punching, if you know (or can inject/configure) the network interface IP that should be used (often the container's or host's primary IP), pass that explicitly in place of `'0.0.0.0'`. The best fix is to add an argument to the `yolo_quic_server` function, say `local_ip="127.0.0.1"` or as appropriate, and use it in `sock.bind((local_ip, local_port))`. If you cannot know the public IP, binding to `"127.0.0.1"` will ensure listening only on the loopback interface (the most restrictive/security). If the behaviour requires a routable interface, document and configure accordingly.

Edit misc/quic/quic_yolo_modal.py:
- Change line 416 from `sock.bind(("0.0.0.0", local_port))` to use a configurable local interface IP, not `"0.0.0.0"`.
- Add a `local_ip` argument (with a safe default) to the function signature at line 405.

No external imports or library changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
