### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
@@ -4,7 +4,7 @@ import time
 from typing import List, NamedTuple
 
 from fastapi import FastAPI, Request, HTTPException
-
+import os
 from . import config
 from .main import (
     get_episode_metadata_path,
@@ -32,6 +32,13 @@ class InProgressJob(NamedTuple):
 async def get_episode(podcast_id: str, episode_guid_hash: str):
     episode_metadata_path = get_episode_metadata_path(podcast_id, episode_guid_hash)
     transcription_path = get_transcript_path(episode_guid_hash)
+
+    # Validate that episode_metadata_path is strictly inside PODCAST_METADATA_DIR
+    base_dir = config.PODCAST_METADATA_DIR
+    norm_metadata_path = os.path.normpath(str(episode_metadata_path))
+    norm_base_dir = os.path.normpath(str(base_dir))
+    if not norm_metadata_path.startswith(norm_base_dir):
+        raise HTTPException(status_code=400, detail="Invalid podcast_id or episode_guid_hash")
 
     web_app.state.volume.reload()
 


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/modal-examples/security/code-scanning/2](https://github.com/hixio-mh/modal-examples/security/code-scanning/2)

The code should validate that the constructed episode metadata path is strictly within the intended base directory (`config.PODCAST_METADATA_DIR`). This is best accomplished by:
1. Normalizing the constructed path with `os.path.normpath`.
2. Normalizing the base directory.
3. Checking that the normalized metadata path starts with the normalized base directory path.
4. If the check fails, raise a fastapi `HTTPException` with an appropriate error.

These changes should be made in the `get_episode` function within `06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py`.  
This fix will require the addition of an import for `os` at the top of the file (unless it is already imported).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
