### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
@@ -38,7 +38,12 @@ async def get_episode(podcast_id: str, episode_guid_hash: str):
     try:
         resolved_base_dir = base_dir.resolve(strict=False)
         resolved_metadata_path = episode_metadata_path.resolve(strict=False)
-        resolved_metadata_path.relative_to(resolved_base_dir)
+        # Use os.path.commonpath to strictly check containment
+        base_path_str = str(resolved_base_dir)
+        metadata_path_str = str(resolved_metadata_path)
+        common_path = os.path.commonpath([base_path_str, metadata_path_str])
+        if common_path != base_path_str:
+            raise HTTPException(status_code=400, detail="Invalid podcast_id or episode_guid_hash")
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid podcast_id or episode_guid_hash")
 


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/modal-examples/security/code-scanning/2](https://github.com/hixio-mh/modal-examples/security/code-scanning/2)

To fully secure the path against traversal and other exploits:
- Normalize the path using `os.path.normpath` or preferably resolve both base and episode paths, ensuring that episode path starts with the resolved base directory path (as a string prefix), and compare via `os.path.commonpath` for stricter checks.
- For best cross-platform safety, convert both paths to absolute paths before checking they share the expected prefix. Consider using `os.path.commonpath` to ensure the metadata file really lives inside the podcast directory.
- The existing exception handling should remain to stop invalid requests.
- Update the validation on lines 36-43 in `get_episode` in `app/api.py` to use both normalization and prefix checking via `os.path.commonpath` (with `str` conversion if necessary).
- Add the `os.path` import if needed (though `os` is already imported).
- Optionally, use `werkzeug.utils.secure_filename` or introduce a stricter allow list for `podcast_id`, but the general recommendation is to enforce via containment in the directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
