### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -1,4 +1,6 @@
 name: Run changed examples
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/modal-examples/security/code-scanning/18](https://github.com/hixio-mh/modal-examples/security/code-scanning/18)

To fix this problem, you should add a `permissions:` block to the workflow file. Ideally, this block should be placed at the workflow root level (above `jobs:`), so its permissions apply to all jobs by default, unless they have their own overrides. The minimal permission required in this case is most likely `contents: read`, since the workflow checks out code and runs scripts but does not push changes, create releases, or modify issues or pull requests. Insert the following block near the top of the file, just below the `name:` entry (before `on:` is customary). No external methods or imports are required; this change is strictly to the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
