### PR TITLE
Potential fix for code scanning alert no. 22: Uncontrolled data used in path expression

### DIFF
--- a/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
+++ b/06_gpu_and_ml/openai_whisper/pod_transcriber/app/api.py
@@ -30,6 +30,14 @@ class InProgressJob(NamedTuple):
 
 @web_app.get("/api/episode/{podcast_id}/{episode_guid_hash}")
 async def get_episode(podcast_id: str, episode_guid_hash: str):
+    # Sanitize podcast_id and episode_guid_hash to avoid path traversal or illegal characters
+    import re
+    def is_safe_component(component):
+        # Only allow alphanumeric, underscore, dash (common for IDs/hashes)
+        return re.fullmatch(r'[A-Za-z0-9_\-]+', component) is not None
+    if not is_safe_component(podcast_id) or not is_safe_component(episode_guid_hash):
+        raise HTTPException(status_code=400, detail="Invalid podcast_id or episode_guid_hash")
+
     episode_metadata_path = get_episode_metadata_path(podcast_id, episode_guid_hash)
     transcription_path = get_transcript_path(episode_guid_hash)
 


### PR DESCRIPTION
Potential fix for [https://github.com/hixio-mh/modal-examples/security/code-scanning/22](https://github.com/hixio-mh/modal-examples/security/code-scanning/22)

To securely validate any path derived from user input, we need to ensure it is strictly contained within the intended base directory, accounting for both path traversal attacks and symlinks. The best way is to resolve both the base directory and the constructed path (with `strict=False` to avoid failure if the path doesn't exist yet), and then ensure the resolved path is both contained in the base directory and not pointing to a symlink outside it. Also, validating that no path segment in `podcast_id` or `guid_hash` contains path traversal attempts (e.g., '..', absolute paths, or path separators) is recommended. We can sanitize the components with a regex or simply check that each part is a filename-safe string (e.g., using `werkzeug.utils.secure_filename` or a Python equivalent). The fix will involve:

- Adding checks that `podcast_id` and `episode_guid_hash` are safe (do not contain path traversal sequences, path separators, empty, etc.)
- Relying on `os.path.commonpath` after resolving, but also rejecting any path containing unexpected segments before even joining/constructing the file path.
- Possibly using a regular expression or `os.path.basename` to ensure IDs are only allowed to be simple safe strings.
- These changes will be made in the `get_episode` function in `app/api.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
